### PR TITLE
Fixes docker image cross-build (part 2)

### DIFF
--- a/Material/Scripts/release.py
+++ b/Material/Scripts/release.py
@@ -16,7 +16,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def check_version(version: str) -> bool:
+def check_version(version: str) -> None:
     """
     Check whether a given version is in expected format and actually newer than the
     current version.
@@ -26,9 +26,6 @@ def check_version(version: str) -> bool:
 
     with open(VERSION_FILE, "r") as f:
         current_version = f.read().strip()
-
-    version = version.strip("v")
-    current_version = current_version.strip("v")
 
     def parse_version(version: str):
         return tuple(map(int, version.split(".")))

--- a/SC.Service/Dockerfile
+++ b/SC.Service/Dockerfile
@@ -1,8 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS base
-WORKDIR /app
-EXPOSE 80
-EXPOSE 443
-
+# >>> 1st stage: build the application
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 ARG TARGETARCH
 ARG BUILDPLATFORM
@@ -13,17 +9,21 @@ RUN dotnet restore "SC.Service/SC.Service.csproj"
 WORKDIR "/src/SC.Service"
 RUN dotnet build "SC.Service.csproj" -c Release -o /app/build -a $TARGETARCH
 
+# >>> 2nd stage: publish the application
 FROM build AS publish
 RUN dotnet publish "SC.Service.csproj" -c Release -o /app/publish \
     --self-contained true \
-    /p:PublishTrimmed=true \
     /p:PublishSingleFile=true \
     -a $TARGETARCH
 
-FROM --platform=$BUILDPLATFORM base AS final
+# >>> 3rd stage: create the final image
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS final
 LABEL org.opencontainers.image.source="https://github.com/merschformann/sardine-can"
 ARG TARGETARCH
 ARG BUILDPLATFORM
+ENV ASPNETCORE_HTTP_PORTS=80
+EXPOSE 80
+WORKDIR /app
 
 # create a new user and change directory ownership
 RUN adduser --disabled-password \
@@ -32,7 +32,7 @@ RUN adduser --disabled-password \
 
 # impersonate into the new user
 USER dotnetuser
-WORKDIR /app
 
+# copy the published files and configure the entrypoint
 COPY --from=publish /app/publish .
 ENTRYPOINT ["./SC.Service"]

--- a/SC.Service/Dockerfile
+++ b/SC.Service/Dockerfile
@@ -1,14 +1,38 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+ARG TARGETARCH
+ARG BUILDPLATFORM
+
 WORKDIR /src
 COPY . .
 RUN dotnet restore "SC.Service/SC.Service.csproj"
 WORKDIR "/src/SC.Service"
-RUN dotnet build "SC.Service.csproj" -c Release -o /app/build
-RUN dotnet publish "SC.Service.csproj" -c Release -o /app/publish
+RUN dotnet build "SC.Service.csproj" -c Release -o /app/build -a $TARGETARCH
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+FROM build AS publish
+RUN dotnet publish "SC.Service.csproj" -c Release -o /app/publish \
+    --self-contained true \
+    /p:PublishTrimmed=true \
+    /p:PublishSingleFile=true \
+    -a $TARGETARCH
+
+FROM --platform=$BUILDPLATFORM base AS final
 LABEL org.opencontainers.image.source="https://github.com/merschformann/sardine-can"
+ARG TARGETARCH
+ARG BUILDPLATFORM
+
+# create a new user and change directory ownership
+RUN adduser --disabled-password \
+    --home /app \
+    --gecos '' dotnetuser && chown -R dotnetuser /app
+
+# impersonate into the new user
+USER dotnetuser
 WORKDIR /app
-EXPOSE 80
-COPY --from=build /app/publish .
-ENTRYPOINT ["dotnet", "SC.Service.dll"]
+
+COPY --from=publish /app/publish .
+ENTRYPOINT ["./SC.Service"]


### PR DESCRIPTION
# Description

This PR means to fix the arm64 docker image (cross-built on amd64) by using a self-contained single binary build (previously dotnet included amd64 .so files on an arm64 build for non-intuitive reasons). This should finally make the new `linux/arm64` work properly.

## Changes

- Restructures `SC.Service` Dockerfile build to create a single binary build to wrap up in the docker image
  - Side-effect: reduces the docker image size from previously `327MB` to `121MB`
- Reverts the default internal port to `80` for better backwards compatibility
- Minor release script improvements