### PR TITLE
Supports forbidden orientations via JSON

### DIFF
--- a/SC.ObjectModel/IO/Json/JsonPiece.cs
+++ b/SC.ObjectModel/IO/Json/JsonPiece.cs
@@ -16,7 +16,9 @@ namespace SC.ObjectModel.IO.Json
         public double Weight { get; set; }
         [JsonPropertyName("flags")]
         public List<JsonFlag> Flags { get; set; }
-        [JsonPropertyName("forbidden_orientations")]
+        [JsonPropertyName("allowedOrientations")]
+        public List<int> AllowedOrientations { get; set; }
+        [JsonPropertyName("forbiddenOrientations")]
         public List<int> ForbiddenOrientations { get; set; }
         [JsonPropertyName("cubes")]
         public List<JsonCube> Cubes { get; set; }

--- a/SC.ObjectModel/IO/Json/JsonPiece.cs
+++ b/SC.ObjectModel/IO/Json/JsonPiece.cs
@@ -16,6 +16,8 @@ namespace SC.ObjectModel.IO.Json
         public double Weight { get; set; }
         [JsonPropertyName("flags")]
         public List<JsonFlag> Flags { get; set; }
+        [JsonPropertyName("forbidden_orientations")]
+        public List<int> ForbiddenOrientations { get; set; }
         [JsonPropertyName("cubes")]
         public List<JsonCube> Cubes { get; set; }
     }

--- a/SC.ObjectModel/InstanceIO.cs
+++ b/SC.ObjectModel/InstanceIO.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
+using Microsoft.VisualBasic;
 
 namespace SC.ObjectModel
 {
@@ -239,8 +240,16 @@ namespace SC.ObjectModel
                 var convp = new VariablePiece() { ID = p.ID, Weight = p.Weight };
                 if (p.Flags != null)
                     convp.SetFlags(p.Flags.Select(f => (f.FlagId, f.FlagValue)));
-                if (p.ForbiddenOrientations != null)
+                
+                if (p.ForbiddenOrientations != null && p.AllowedOrientations == null)
                     convp.ForbiddenOrientations = new(p.ForbiddenOrientations);
+                if (p.AllowedOrientations != null)
+                {
+                    convp.ForbiddenOrientations = MeshConstants.ORIENTATIONS.Except(p.AllowedOrientations).ToHashSet();
+                    if (p.ForbiddenOrientations != null)
+                        convp.ForbiddenOrientations.UnionWith(p.ForbiddenOrientations);
+                }
+                
                 foreach (var comp in p.Cubes)
                     convp.AddComponent(comp.X, comp.Y, comp.Z, comp.Length, comp.Width, comp.Height);
                 return convp;

--- a/SC.ObjectModel/InstanceIO.cs
+++ b/SC.ObjectModel/InstanceIO.cs
@@ -239,6 +239,8 @@ namespace SC.ObjectModel
                 var convp = new VariablePiece() { ID = p.ID, Weight = p.Weight };
                 if (p.Flags != null)
                     convp.SetFlags(p.Flags.Select(f => (f.FlagId, f.FlagValue)));
+                if (p.ForbiddenOrientations != null)
+                    convp.ForbiddenOrientations = new(p.ForbiddenOrientations);
                 foreach (var comp in p.Cubes)
                     convp.AddComponent(comp.X, comp.Y, comp.Z, comp.Length, comp.Width, comp.Height);
                 return convp;
@@ -286,6 +288,7 @@ namespace SC.ObjectModel
                         ID = p.ID,
                         Weight = p.Weight,
                         Flags = p.GetFlags().Select(f => new JsonFlag() { FlagId = f.flag, FlagValue = f.value }).ToList(),
+                        ForbiddenOrientations = p.ForbiddenOrientations.ToList(),
                         Cubes = p.Original.Components.Select(c =>
                             new JsonCube()
                             {


### PR DESCRIPTION
# Description

Supports more functionality via the JSON input format.

## Changes

* Adding support for `forbiddenOrientations` and `allowedOrientations`. The latter is only supported when reading and converted to the former on-the-fly.